### PR TITLE
feat: add endpoint to get wishlist product timestamps (closes #23)

### DIFF
--- a/docs/swagger/swagger.yml
+++ b/docs/swagger/swagger.yml
@@ -541,6 +541,27 @@ definitions:
                 x-go-name: Total
         type: object
         x-go-package: github.com/nurdsoft/nurd-commerce-core/internal/cart/entities
+    GetWishlistProductTimestampsRequestBody:
+        properties:
+            product_ids:
+                items:
+                    format: uuid
+                    type: string
+                type: array
+                x-go-name: ProductIDs
+        type: object
+        x-go-package: github.com/nurdsoft/nurd-commerce-core/internal/wishlist/entities
+    GetWishlistProductTimestampsResponse:
+        properties:
+            timestamps:
+                additionalProperties:
+                    format: date-time
+                    type: string
+                description: Map of product ID to wishlist timestamp
+                type: object
+                x-go-name: Timestamps
+        type: object
+        x-go-package: github.com/nurdsoft/nurd-commerce-core/internal/wishlist/entities
     GetWishlistResponse:
         properties:
             items:
@@ -1814,6 +1835,34 @@ paths:
                     schema:
                         $ref: '#/definitions/DefaultError'
             summary: Get More from Wishlist
+            tags:
+                - wishlist
+    /wishlist/timestamps:
+        post:
+            description: '### Retrieve the timestamps when products were added to the customer''s wishlist'
+            operationId: GetWishlistProductTimestampsRequest
+            parameters:
+                - description: Products to get timestamps for
+                  in: body
+                  name: Body
+                  schema:
+                    $ref: '#/definitions/GetWishlistProductTimestampsRequestBody'
+            produces:
+                - application/json
+            responses:
+                "200":
+                    description: Timestamps retrieved successfully
+                    schema:
+                        $ref: '#/definitions/GetWishlistProductTimestampsResponse'
+                "400":
+                    description: Bad Request
+                    schema:
+                        $ref: '#/definitions/DefaultError'
+                "500":
+                    description: Internal Server Error
+                    schema:
+                        $ref: '#/definitions/DefaultError'
+            summary: Get Wishlist Product Timestamps
             tags:
                 - wishlist
 produces:

--- a/internal/wishlist/endpoints/endpoints.go
+++ b/internal/wishlist/endpoints/endpoints.go
@@ -3,24 +3,26 @@ package endpoints
 import (
 	"context"
 
+	"github.com/go-kit/kit/endpoint"
 	"github.com/nurdsoft/nurd-commerce-core/internal/wishlist/entities"
 	"github.com/nurdsoft/nurd-commerce-core/internal/wishlist/service"
-	"github.com/go-kit/kit/endpoint"
 )
 
 type Endpoints struct {
-	AddToWishlistEndpoint       endpoint.Endpoint
-	RemoveFromWishlistEndpoint  endpoint.Endpoint
-	GetWishlistEndpoint         endpoint.Endpoint
-	GetMoreFromWishlistEndpoint endpoint.Endpoint
+	AddToWishlistEndpoint                endpoint.Endpoint
+	RemoveFromWishlistEndpoint           endpoint.Endpoint
+	GetWishlistEndpoint                  endpoint.Endpoint
+	GetMoreFromWishlistEndpoint          endpoint.Endpoint
+	GetWishlistProductTimestampsEndpoint endpoint.Endpoint
 }
 
 func New(svc service.Service) *Endpoints {
 	return &Endpoints{
-		AddToWishlistEndpoint:       makeAddToWishlist(svc),
-		RemoveFromWishlistEndpoint:  makeRemoveFromWishlist(svc),
-		GetWishlistEndpoint:         makeGetWishlist(svc),
-		GetMoreFromWishlistEndpoint: makeGetMoreFromWishlist(svc),
+		AddToWishlistEndpoint:                makeAddToWishlist(svc),
+		RemoveFromWishlistEndpoint:           makeRemoveFromWishlist(svc),
+		GetWishlistEndpoint:                  makeGetWishlist(svc),
+		GetMoreFromWishlistEndpoint:          makeGetMoreFromWishlist(svc),
+		GetWishlistProductTimestampsEndpoint: makeGetWishlistProductTimestamps(svc),
 	}
 }
 
@@ -55,5 +57,14 @@ func makeGetMoreFromWishlist(svc service.Service) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req := request.(*entities.GetMoreFromWishlistRequest) //nolint:errcheck
 		return svc.GetMoreFromWishlist(ctx, req)
+	}
+}
+
+func makeGetWishlistProductTimestamps(svc service.Service) endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (interface{}, error) {
+		req := request.(*entities.GetWishlistProductTimestampsRequest) //nolint:errcheck
+		timestamps, err := svc.GetWishlistProductTimestamps(ctx, req)
+
+		return timestamps, err
 	}
 }

--- a/internal/wishlist/entities/requests.go
+++ b/internal/wishlist/entities/requests.go
@@ -66,3 +66,15 @@ type GetMoreFromWishlistRequest struct {
 	// in:query
 	Cursor string `json:"cursor"`
 }
+
+// swagger:parameters wishlist GetWishlistProductTimestampsRequest
+type GetWishlistProductTimestampsRequest struct {
+	// Products to get timestamps for
+	//
+	// in:body
+	Body *GetWishlistProductTimestampsRequestBody
+}
+
+type GetWishlistProductTimestampsRequestBody struct {
+	ProductIDs []uuid.UUID `json:"product_ids"`
+}

--- a/internal/wishlist/entities/response.go
+++ b/internal/wishlist/entities/response.go
@@ -1,7 +1,15 @@
 package entities
 
+import "time"
+
 // swagger:model GetWishlistResponse
 type GetWishlistResponse struct {
 	Items      []*WishlistItem `json:"items"`
 	NextCursor string          `json:"next_cursor"`
+}
+
+// swagger:model GetWishlistProductTimestampsResponse
+type GetWishlistProductTimestampsResponse struct {
+	// Map of product ID to wishlist timestamp
+	Timestamps map[string]time.Time `json:"timestamps"`
 }

--- a/internal/wishlist/repository/mock_repository.go
+++ b/internal/wishlist/repository/mock_repository.go
@@ -7,6 +7,7 @@ package repository
 import (
 	context "context"
 	reflect "reflect"
+	time "time"
 
 	gomock "github.com/golang/mock/gomock"
 	uuid "github.com/google/uuid"
@@ -78,6 +79,21 @@ func (m *MockRepository) GetWishlist(ctx context.Context, customerID string, lim
 func (mr *MockRepositoryMockRecorder) GetWishlist(ctx, customerID, limit, cursor interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWishlist", reflect.TypeOf((*MockRepository)(nil).GetWishlist), ctx, customerID, limit, cursor)
+}
+
+// GetWishlistProductTimestamps mocks base method.
+func (m *MockRepository) GetWishlistProductTimestamps(customerID string, productIDs []uuid.UUID) (map[string]time.Time, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetWishlistProductTimestamps", customerID, productIDs)
+	ret0, _ := ret[0].(map[string]time.Time)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetWishlistProductTimestamps indicates an expected call of GetWishlistProductTimestamps.
+func (mr *MockRepositoryMockRecorder) GetWishlistProductTimestamps(customerID, productIDs interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWishlistProductTimestamps", reflect.TypeOf((*MockRepository)(nil).GetWishlistProductTimestamps), customerID, productIDs)
 }
 
 // UpdateWishlist mocks base method.

--- a/internal/wishlist/repository/repository.go
+++ b/internal/wishlist/repository/repository.go
@@ -3,6 +3,7 @@ package repository
 import (
 	"context"
 	"database/sql"
+	"time"
 
 	"github.com/nurdsoft/nurd-commerce-core/internal/wishlist/entities"
 
@@ -15,6 +16,7 @@ type Repository interface {
 	DeleteFromWishlist(ctx context.Context, customerID string, productID uuid.UUID) error
 	GetWishlist(ctx context.Context, customerID string, limit int, cursor string) ([]*entities.WishlistItem, string, error)
 	BulkRemoveFromWishlist(ctx context.Context, customerID uuid.UUID, productIDs []uuid.UUID) error
+	GetWishlistProductTimestamps(customerID string, productIDs []uuid.UUID) (map[string]time.Time, error)
 }
 
 // New repository for wishlist.

--- a/internal/wishlist/repository/sql_repository.go
+++ b/internal/wishlist/repository/sql_repository.go
@@ -99,3 +99,28 @@ func (r *sqlRepository) BulkRemoveFromWishlist(ctx context.Context, customerID u
 
 	return nil
 }
+
+func (r *sqlRepository) GetWishlistProductTimestamps(customerID string, productIDs []uuid.UUID) (map[string]time.Time, error) {
+	// map of product_id to the added_at time
+	res := map[string]time.Time{}
+
+	rows, err := r.gormDB.Table("wishlist_items").
+		Select("product_id, created_at").
+		Where("customer_id = ? AND product_id IN ?", customerID, productIDs).
+		Rows()
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var productID string
+		var createdAt time.Time
+		if err := rows.Scan(&productID, &createdAt); err != nil {
+			return nil, err
+		}
+		res[productID] = createdAt
+	}
+
+	return res, nil
+}

--- a/internal/wishlist/transport/http/decode.go
+++ b/internal/wishlist/transport/http/decode.go
@@ -6,16 +6,17 @@ import (
 	"net/http"
 	"strconv"
 
+	"github.com/google/uuid"
+	"github.com/gorilla/mux"
 	"github.com/nurdsoft/nurd-commerce-core/internal/wishlist/entities"
 	moduleErrors "github.com/nurdsoft/nurd-commerce-core/internal/wishlist/errors"
 	httpError "github.com/nurdsoft/nurd-commerce-core/shared/errors/http"
-	"github.com/google/uuid"
-	"github.com/gorilla/mux"
 	"github.com/pkg/errors"
 )
 
 type RequestBodyType interface {
-	entities.AddToWishlistRequestBody
+	entities.AddToWishlistRequestBody |
+		entities.GetWishlistProductTimestampsRequestBody
 }
 
 func decodeBodyFromRequest[T RequestBodyType](req *T, r *http.Request) error {
@@ -84,5 +85,17 @@ func decodeGetMoreFromWishlistRequest(_ context.Context, r *http.Request) (inter
 	return &entities.GetMoreFromWishlistRequest{
 		Limit:  limit,
 		Cursor: r.URL.Query().Get("cursor"),
+	}, nil
+}
+
+func decodeGetWishlistProductTimestampsRequest(_ context.Context, r *http.Request) (interface{}, error) {
+	reqBody := &entities.GetWishlistProductTimestampsRequestBody{}
+	err := decodeBodyFromRequest(reqBody, r)
+	if err != nil {
+		return nil, err
+	}
+
+	return &entities.GetWishlistProductTimestampsRequest{
+		Body: reqBody,
 	}, nil
 }


### PR DESCRIPTION
<!-- 
🎯 Title Format: [fix|feature|chore]: Brief summary of the change 
-->

## ✨ Summary
Adds a new endpoint to retrieve wishlist product timestamps.

<!-- 
What’s this PR about? 
Include:
- A short description of the change
- Related issue/ticket link (if any)
- Motivation/context
- Any dependencies or setup required
-->

## Changes
- Added service method `GetWishlistProductTimestamps`
- Implemented endpoint `/wishlist/timestamps`
- Added unit tests
- Added Swagger documentation
- Added response struct `GetWishlistProductTimestampsResponse`


## ✅ Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed code for logic and readability
- [x] Added comments for complex logic
- [x] Updated documentation (README, config files, etc.)
- [x] No new warnings introduced
- [x] Added/updated tests for new/changed logic
- [x] All tests pass locally

<!-- 
Optional: Tag reviewers or add notes for QA/testing 
-->
