### PR TITLE
fix: null json append when merging json objects in order `fulfillment_metadata`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,6 +108,9 @@ start-env: ## Start the local env
 	docker-compose up -d otel-collector
 	docker-compose up -d db
 
+start-db: ## Start the local db
+	docker-compose up -d db
+
 start-app: ## Start the application in docker container
 	docker-compose up --build api
 


### PR DESCRIPTION
<!-- 
🎯 Title Format: [fix|feature|chore]: Brief summary of the change 
-->

## ✨ Summary

SQL NULL is different from JSONB NULL. In case the initial value of the column is null (either of the cases), the Order `Update` method will successfully append/merge the JSON object


## 📸 Demo / Screenshots

<!-- 
Add screenshots, GIFs, or screencasts if this is a visual change 
-->

## ✅ Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed code for logic and readability
- [x] Added comments for complex logic
- [ ] Updated documentation (README, config files, etc.)
- [x] No new warnings introduced
- [ ] Added/updated tests for new/changed logic
- [ ] All tests pass locally

<!-- 
Optional: Tag reviewers or add notes for QA/testing 
-->
