### PR TITLE
fix: return all wishlist items in case of empty cart

### DIFF
--- a/internal/wishlist/service/service.go
+++ b/internal/wishlist/service/service.go
@@ -2,6 +2,9 @@ package service
 
 import (
 	"context"
+	"sort"
+	"sync"
+
 	"github.com/google/uuid"
 	"github.com/nurdsoft/nurd-commerce-core/internal/cart/cartclient"
 	cartEntities "github.com/nurdsoft/nurd-commerce-core/internal/cart/entities"
@@ -13,8 +16,6 @@ import (
 	"github.com/nurdsoft/nurd-commerce-core/shared/cfg"
 	sharedMeta "github.com/nurdsoft/nurd-commerce-core/shared/meta"
 	"go.uber.org/zap"
-	"sort"
-	"sync"
 )
 
 type Service interface {
@@ -184,7 +185,6 @@ func (s *service) BulkRemoveFromWishlist(ctx context.Context, req *entities.Bulk
 //	404: DefaultError Not Found
 //	500: DefaultError Internal Server Error
 func (s *service) GetMoreFromWishlist(ctx context.Context, req *entities.GetMoreFromWishlistRequest) (*entities.GetWishlistResponse, error) {
-
 	customerID := sharedMeta.XCustomerID(ctx)
 
 	if customerID == "" {
@@ -228,6 +228,15 @@ func (s *service) GetMoreFromWishlist(ctx context.Context, req *entities.GetMore
 		return nil, nil
 	}
 
+	if cartItems == nil {
+		// If there are no items in the cart, return all wishlist items
+		// Ideally, this should not happen if the calling frontend is properly managing the empty cart state
+		return &entities.GetWishlistResponse{
+			Items:      wishlistItems,
+			NextCursor: nextCursor,
+			Total:      int64(len(wishlistItems)),
+		}, nil
+	}
 	// Create a set of product IDs that are in the cart
 	cartProductIDs := make(map[string]struct{}, len(cartItems.Items))
 	for _, item := range cartItems.Items {

--- a/internal/wishlist/service/service.go
+++ b/internal/wishlist/service/service.go
@@ -228,9 +228,14 @@ func (s *service) GetMoreFromWishlist(ctx context.Context, req *entities.GetMore
 		return nil, nil
 	}
 
-	if cartItems == nil {
+	if cartItems == nil || len(cartItems.Items) == 0 {
 		// If there are no items in the cart, return all wishlist items
 		// Ideally, this should not happen if the calling frontend is properly managing the empty cart state
+		// sort items by created_at
+		sort.Slice(wishlistItems, func(i, j int) bool {
+			return wishlistItems[i].CreatedAt.After(wishlistItems[j].CreatedAt)
+		})
+
 		return &entities.GetWishlistResponse{
 			Items:      wishlistItems,
 			NextCursor: nextCursor,

--- a/internal/wishlist/service/service_test.go
+++ b/internal/wishlist/service/service_test.go
@@ -645,9 +645,7 @@ func Test_service_GetMoreFromWishlist(t *testing.T) {
 		// Another product only in wishlist
 		wishlistOnlyProductID := uuid.New()
 
-		mockCartClient.EXPECT().GetCartItems(ctx).Return(&cartEntities.GetCartItemsResponse{
-			Items: []cartEntities.CartItemDetail{},
-		}, nil).Times(1)
+		mockCartClient.EXPECT().GetCartItems(ctx).Return(nil, nil).Times(1)
 
 		// Create wishlist with two products - one in cart, one not in cart
 		creationTime := time.Now()

--- a/internal/wishlist/service/service_test.go
+++ b/internal/wishlist/service/service_test.go
@@ -634,6 +634,47 @@ func Test_service_GetMoreFromWishlist(t *testing.T) {
 		// Explicitly verify the timestamps are in the correct order
 		assert.True(t, resp.Items[0].CreatedAt.After(resp.Items[1].CreatedAt))
 	})
+
+	t.Run("Empty cart results in all wishlist items", func(t *testing.T) {
+		svc, ctx, mockRepo, mockCartClient := setup()
+		req := &entities.GetMoreFromWishlistRequest{}
+
+		// Create a product that will be in both cart and wishlist
+		sharedProductID := uuid.New()
+
+		// Another product only in wishlist
+		wishlistOnlyProductID := uuid.New()
+
+		mockCartClient.EXPECT().GetCartItems(ctx).Return(&cartEntities.GetCartItemsResponse{
+			Items: []cartEntities.CartItemDetail{},
+		}, nil).Times(1)
+
+		// Create wishlist with two products - one in cart, one not in cart
+		creationTime := time.Now()
+		mockRepo.EXPECT().GetWishlist(ctx, meta.XCustomerID(ctx), 0, "").Return([]*entities.WishlistItem{
+			{
+				Id:         uuid.New(),
+				CustomerID: customerUUID,
+				ProductID:  sharedProductID,
+				CreatedAt:  creationTime,
+			},
+			{
+				Id:         uuid.New(),
+				CustomerID: customerUUID,
+				ProductID:  wishlistOnlyProductID,
+				CreatedAt:  creationTime,
+			},
+		}, "", int64(0), nil).Times(1)
+
+		resp, err := svc.GetMoreFromWishlist(ctx, req)
+
+		assert.NoError(t, err)
+		assert.NotNil(t, resp)
+		// Both products should be returned since cart is empty
+		assert.Equal(t, 2, len(resp.Items))
+		assert.Equal(t, sharedProductID, resp.Items[0].ProductID)
+		assert.Equal(t, wishlistOnlyProductID, resp.Items[1].ProductID)
+	})
 }
 
 func Test_service_GetWishlistProductTimestamps(t *testing.T) {


### PR DESCRIPTION
<!-- 
🎯 Title Format: [fix|feature|chore]: Brief summary of the change 
-->

## ✨ Summary

When the `/wishlist/more` endpoint is called in case of empty cart state, it errors. If merged, this PR adds a fix to return all the wishlist items in case the cart is empty.


## ✅ Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed code for logic and readability
- [x] Added comments for complex logic
- [ ] Updated documentation (README, config files, etc.)
- [ ] No new warnings introduced
- [ ] Added/updated tests for new/changed logic
- [x] All tests pass locally

<!-- 
Optional: Tag reviewers or add notes for QA/testing 
-->
