### PR TITLE
fix: empty tax provider not working properly

### DIFF
--- a/shared/vendors/inventory/config.go
+++ b/shared/vendors/inventory/config.go
@@ -15,6 +15,8 @@ type Config struct {
 // Validate config.
 func (c *Config) Validate() error {
 	switch c.Provider {
+	case providers.ProviderNone:
+		return nil
 	case providers.ProviderSalesforce:
 		return c.Salesforce.Validate()
 	default:

--- a/shared/vendors/shipping/config.go
+++ b/shared/vendors/shipping/config.go
@@ -8,6 +8,7 @@ import (
 )
 
 const (
+	ProviderNone       string = "none"
 	ProviderShipengine string = "Shipengine"
 	ProviderUPS        string = "UPS"
 )
@@ -22,7 +23,7 @@ type Config struct {
 // Validate config.
 func (c *Config) Validate() error {
 	switch c.Provider {
-	case "":
+	case "", ProviderNone:
 		return nil
 	case ProviderShipengine:
 		return c.Shipengine.Validate()

--- a/shared/vendors/shipping/module.go
+++ b/shared/vendors/shipping/module.go
@@ -28,7 +28,7 @@ type ModuleParams struct {
 // nolint:gocritic
 func NewModule(p ModuleParams) (client.Client, error) {
 	switch p.Config.Provider {
-	case "":
+	case "", ProviderNone:
 		return fakeprovider.NewClient(), nil
 	case ProviderShipengine:
 		service, err := shipengineService.New(p.HttpClient, p.Config.Shipengine, p.Logger)

--- a/shared/vendors/taxes/config.go
+++ b/shared/vendors/taxes/config.go
@@ -17,7 +17,7 @@ type Config struct {
 // Validate config.
 func (c *Config) Validate() error {
 	switch c.Provider {
-	case "":
+	case "", providers.ProviderNone:
 		return nil
 	case providers.ProviderStripe:
 		return c.Stripe.Validate()

--- a/shared/vendors/taxes/providers/providers.go
+++ b/shared/vendors/taxes/providers/providers.go
@@ -5,5 +5,6 @@ type (
 )
 
 const (
+	ProviderNone   ProviderType = "none"
 	ProviderStripe ProviderType = "stripe"
 )


### PR DESCRIPTION
<!-- 
🎯 Title Format: [fix|feature|chore]: Brief summary of the change 
-->

## ✨ Summary

For some reason the empty tax provider is not working in Cloud Run. It does running locally. 

So changing to support `none` as an input in both shipping and taxes providers, just like we had for inventory. 

## 💥 Breaking Changes

<!-- 
Remove this section if there are no breaking changes.

Does this PR introduce breaking changes?
- What will break?
- What action is required by consumers (if any)?
-->

## 📸 Demo / Screenshots

<!-- 
Add screenshots, GIFs, or screencasts if this is a visual change 
-->

## ✅ Checklist

- [ ] Code follows project style guidelines
- [ ] Self-reviewed code for logic and readability
- [ ] Added comments for complex logic
- [ ] Updated documentation (README, config files, etc.)
- [ ] No new warnings introduced
- [ ] Added/updated tests for new/changed logic
- [ ] All tests pass locally

<!-- 
Optional: Tag reviewers or add notes for QA/testing 
-->
